### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/surajchidarala/13968c41-7bc7-4a67-a23c-e101c231a450/b2752f26-ddee-41fd-9b0b-4faba976f2c0/_apis/work/boardbadge/5c4e5515-bbb1-4899-bfaa-9f7757d4bbd1)](https://dev.azure.com/surajchidarala/13968c41-7bc7-4a67-a23c-e101c231a450/_boards/board/t/b2752f26-ddee-41fd-9b0b-4faba976f2c0/Microsoft.RequirementCategory)
 # Fitness


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/surajchidarala/13968c41-7bc7-4a67-a23c-e101c231a450/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.